### PR TITLE
Prepend timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,13 @@
           "description": "Parent list to append your notes within (i.e. 🗓 Daily Log)",
           "type": "textfield",
           "required": false
+        },
+        {
+          "name": "prependTimestamp",
+          "description": "Prepend a timestamp to your note",
+          "type": "checkbox",
+          "required": false,
+          "label": "Prepend Timestamp"
         }
       ],
       "arguments": [

--- a/src/quickAppend.ts
+++ b/src/quickAppend.ts
@@ -1,4 +1,5 @@
 import { appendToDailyNote, ReflectApiError } from "./api";
+import { processArgumentText } from "./utils";
 import { getPreferenceValues, openExtensionPreferences, LaunchProps } from "@raycast/api";
 import { confirmAlert, showToast, Toast, closeMainWindow } from "@raycast/api";
 
@@ -11,14 +12,7 @@ export default async (props: LaunchProps<{ arguments: Arguments.QuickAppend }>) 
   });
 
   try {
-    if (preferences.prependTimestamp) {
-      const now = new Date();
-      const timestamp = now.toLocaleTimeString("en-US", {
-        hour: "numeric",
-        minute: "numeric"
-      });
-      props.arguments.text = `${timestamp} ${props.arguments.text}`;
-    }
+    props.arguments.text = processArgumentText(props.arguments.text, preferences)
     await appendToDailyNote(
       preferences.authorizationToken,
       preferences.graphId,

--- a/src/quickAppend.ts
+++ b/src/quickAppend.ts
@@ -11,6 +11,14 @@ export default async (props: LaunchProps<{ arguments: Arguments.QuickAppend }>) 
   });
 
   try {
+    if (preferences.prependTimestamp) {
+      const now = new Date();
+      const timestamp = now.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "numeric"
+      });
+      props.arguments.text = `${timestamp} ${props.arguments.text}`;
+    }
     await appendToDailyNote(
       preferences.authorizationToken,
       preferences.graphId,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,15 @@ export function getTodaysDateAsISOString() {
   const today = new Date();
   return new Date(today.getFullYear(), today.getMonth(), today.getDate()).toISOString().substring(0, 10);
 }
+
+export function processArgumentText(text: string, preferences: Preferences.QuickAppend) {
+  if (preferences.prependTimestamp) {
+    const now = new Date();
+    const timestamp = now.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "numeric",
+    });
+    text = `${timestamp} ${text}`;
+  }
+  return text;
+}


### PR DESCRIPTION
Add preference to prepend the timestamp to the note.

Since we aren't able to capture the Reflect preferences (shown below) for 12/24 hour time, I just assumed hours and minutes in the users local time string would suffice. 

Please let me know if you want to me to change any of the preferences copy or know of a more efficient way to prepend the time to the arguments.text